### PR TITLE
lock-sh failed silently

### DIFF
--- a/conf/lock_servers
+++ b/conf/lock_servers
@@ -1,1 +1,1 @@
-lizard
+node1.lan node2.lan node3.lan

--- a/conf/remote_path
+++ b/conf/remote_path
@@ -1,1 +1,0 @@
-/home/vortex/shell-cluster-suite/dex-lock

--- a/dex-init
+++ b/dex-init
@@ -16,6 +16,14 @@ hostname=${hostname%%.*}
 read lock_servers < conf/lock_servers
 i=0; for h in $lock_servers ; do i=$((i+1)); done
 majority=$((i/2+1))
+
+if [ ! -d temp ] ; then
+  mkdir temp
+fi
+if [ ! -d state ] ; then
+  mkdir state
+fi
+
 echo $hostname $majority > temp/${lname}_params
 echo $((timeout+timeout2))  > temp/${lname}_counter
 echo "-invalid-" 0 0 "-invalid-" > temp/${lname}_htsp

--- a/dex-lock
+++ b/dex-lock
@@ -17,7 +17,7 @@ step=${4:-1}
 priority=${4:-1}
 
 read lock_servers < conf/lock_servers
-read rpath        < conf/remote_path
+rpath=$(pwd)
 read sshopt       < conf/sshopt
 read counter      < temp/${lname}_counter
 read holder term seq previous < temp/${lname}_htsp

--- a/dex-release
+++ b/dex-release
@@ -14,7 +14,7 @@ timeout=${2:-30}
 timeout2=${3:-0}
 
 read lock_servers < conf/lock_servers
-read rpath        < conf/remote_path
+rpath=$(pwd)
 read sshopt       < conf/sshopt
 read holder term seq previous < temp/${lname}_htsp
 read hostname majority  < temp/${lname}_params

--- a/dex-show
+++ b/dex-show
@@ -12,7 +12,7 @@ cd ${0%/*}
 lname=${1:-default}
 
 read lock_servers < conf/lock_servers
-read rpath        < conf/remote_path
+rpath=$(pwd)
 read sshopt       < conf/sshopt
 
 if [ -f temp/${lname}_counter ] ; then

--- a/internals/lock-sh
+++ b/internals/lock-sh
@@ -16,7 +16,7 @@ trap 'quit 0' HUP INT TERM
 
 until
    mv temp/lockdir_un temp/lockdir_sh > /dev/null 2>&1 < /dev/null
-   ( echo "" > temp/lockdir_sh/$$ ) > /dev/null 2>&1 < /dev/null
+   ( mkdir -p temp/lockdir_sh ; echo "" > temp/lockdir_sh/$$ ) > /dev/null 2>&1 < /dev/null
 do
    if [ -n "$lock_timeout" ] ; then
       lock_timeout=$((lock_timeout-1))


### PR DESCRIPTION
Hi,

Took me a while to find a bug: in lock-sh this line failed silently:

echo "" > temp/lockdir_sh/$$

because temp/lockdir_sh does not exist. Fixed. Also removed the need for remote_path. I also added 3 nodes to conf/lock_servers. Originally there was only one and I foolishly added 2 more in new lines instead of the same line. Having 3 nodes makes it harder to do wrong (as I did).
